### PR TITLE
Atomic refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 cap-server
+cap-server.debug
+pkg/
+src/
+bin/

--- a/data.go
+++ b/data.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+)
+
+type Answers map[string]map[string]string
+
+// Nulecule
+type Nulecule struct {
+	Specversion string
+	Id          string
+	Metadata    map[string]string
+	Params      map[string]string
+	Graph       []Node
+}
+
+type Node struct {
+	Name   string
+	Source string
+	Params []Param
+}
+
+type Param struct {
+	Name        string
+	Description string
+	Default     string
+	Binds       []string
+}
+
+type Bindings struct {
+	Src     string `json:"src"`
+	SrcKey  string `json:"src_key"`
+	Dest    string `json:"dest"`
+	DestKey string `json:"dest_key"`
+}
+
+// End Nulecule
+
+type NuleculeDetail struct {
+	Nulecule Answers    `json:"nulecule"`
+	Bindings []Bindings `json:"bindings"`
+}
+
+type NuleculeList struct {
+	Nulecules []string `json:"nulecules"`
+}
+
+// Namespace related types
+// This is necessary because we need to strip, and inject back in namespaces
+// to be able to be compatible with atomicapp 0.6.4, which introduced the concept.
+// Not necessary for 0.6.3
+// Example section header atomicapp 0.6.4 expects in the answers file:
+//   -> [mariadb-centos7-atomicapp:mariadb-atomicapp]
+// 0.6.3 only required [mariadb-atomicapp]
+// TODO: Consider a better way to handle this.
+type AtomicAppId string
+
+func NewAtomicAppId(registry string, nuleculeId string) AtomicAppId {
+	return AtomicAppId(fmt.Sprintf("%s/%s", registry, nuleculeId))
+}
+
+// Example namespace: mariadb-centos-atomicapp
+// Example name: mariadb-atomicapp
+type NamespaceToNameMap map[string]string
+type NamespaceManifest map[AtomicAppId]NamespaceToNameMap
+
+func (pManifest *NamespaceManifest) insert(
+	registry string,
+	nuleculeId string,
+	ns string,
+	nodeName string,
+) NamespaceManifest {
+	manifest := *pManifest
+	appId := NewAtomicAppId(registry, nuleculeId)
+	if mapping, ok := manifest[appId]; ok {
+		mapping[ns] = nodeName
+	} else {
+		newMapping := make(NamespaceToNameMap)
+		fmt.Println("inserting ns", ns)
+		fmt.Println("inserting nodeName", nodeName)
+		fmt.Println("newMapping", newMapping)
+		newMapping[ns] = nodeName
+		manifest[appId] = newMapping
+	}
+	return manifest
+}

--- a/download_atomicapp.sh
+++ b/download_atomicapp.sh
@@ -1,1 +1,30 @@
-script -c "atomic run projectatomic/$1 --mode fetch --destination $HOME/nulecules/$1" /dev/null
+#!/bin/bash
+registry="$1"
+nulecule_name="$2"
+nulecule_dir=$HOME/nulecules/$registry/$nulecule_name
+
+echo "============================================================"
+echo "CAP DOWNLOADING NULECULE"
+echo "REGISTRY: $registry"
+echo "NULECULE_NAME: $nulecule_name"
+echo "NULECULE_DIR: $nulecule_dir"
+echo "============================================================"
+
+# Clean whatever is existing since atomic will not overwrite answers
+sudo rm -rf $nulecule_dir
+mkdir -p $nulecule_dir
+
+# Need to wrap atomic calls in "script" to fake a tty
+# atomic runs docker with the -t flag, which will break if this script
+# is called from the go server
+
+# HACK: Really need to clean this up and figure out a better way to script
+# Multiple script commands in sequence within this script will not run
+# sequentially! To make sure these commands execute in sequence, needed to
+# run them all within the script wrapper. Obviously this is very ugly, need
+# to figure out how to clean this up and fix it the proper way.
+script -c "atomic run $registry/$nulecule_name \\
+  --mode fetch --destination $nulecule_dir && \\
+  pushd $nulecule_dir && \\
+  atomic run $registry/$nulecule_name --mode genanswers && \\
+  popd && sudo chown -R vagrant:vagrant $nulecule_dir" /dev/null

--- a/main.go
+++ b/main.go
@@ -3,274 +3,120 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
 	"html/template"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
-	"os/exec"
-	"os/user"
 	"path"
-	"strings"
-
-	yaml "gopkg.in/yaml.v1"
-
-	//"github.com/codeskyblue/go-sh"
-
-	"github.com/gorilla/handlers"
-	"github.com/gorilla/mux"
 )
 
-const MAIN_FILE = "Nulecule"
+// We need to strip namespaces off answer file sections to talk to the
+// front end, but atmoicapp 0.6.4 expects them to be in the answerfile when
+// we go to run it, so it will need to be written out to answer.conf.gen before
+// running a user's answers. We'll keep track of that bookkeeping here
+// TODO: Consider longer term approach than a gross global manifest!
+var namespaceManifest NamespaceManifest
 
-// TODO: create a struct
-type Answers map[string]map[string]string
+func main() {
+	namespaceManifest = make(NamespaceManifest)
 
-func runCommand(cmd string, args ...string) []byte {
-	output, err := exec.Command(cmd, args...).CombinedOutput()
-	if err != nil {
-		fmt.Println("Error running " + cmd)
-	}
-	return output
+	r := mux.NewRouter()
+
+	// API routes
+	r.HandleFunc("/nulecules", Nulecules)
+	r.HandleFunc("/nulecules/{registry}/{id}", NuleculeDetails).Methods("GET")
+	r.HandleFunc("/nulecules/{registry}/{id}", NuleculeUpdate).Methods("POST")
+	r.HandleFunc("/nulecules/{registry}/{id}/deploy", NuleculeDeploy).Methods("POST")
+
+	// Setup static file server at /static/, used for stuff like js
+	fs := http.StripPrefix("/static/", http.FileServer(http.Dir("./static")))
+	r.PathPrefix("/static/").Handler(fs)
+
+	// Serve index template
+	r.HandleFunc("/", IndexHandler)
+
+	fmt.Println("Listening on localhost:3001")
+	allowed_headers := handlers.AllowedHeaders([]string{"Content-Type"})
+	log.Fatal(http.ListenAndServe(":3001", handlers.CORS(
+		allowed_headers,
+	)(r)))
 }
 
-// returns a map of maps
-func parseBasicINI(data string) map[string]map[string]string {
-	/*
-		find first [ then find matching ]. Everything between them is the first key. Read until next [ or end of string.
-	*/
-	var answers = make(map[string]map[string]string)
-	values := strings.SplitAfter(data, "\n")
-	var key string
-	for _, str := range values {
-		if strings.HasPrefix(str, "[") {
-			key = strings.Trim(str, "[]\n")
-			answers[key] = make(map[string]string)
-		} else {
-			subvalue := strings.Split(str, " = ")
-			answers[key][subvalue[0]] = strings.Trim(subvalue[1], "\n")
-		}
-	}
-
-	fmt.Println(answers)
-	return answers
-}
-
-// Nulecule structs
-type Param struct {
-	Name        string
-	Description string
-	Default     string
-	Binds       []string
-}
-
-type Node struct {
-	Name   string
-	Source string
-	Params []Param
-}
-
-type Nulecule struct {
-	Specversion string
-	Id          string
-	Metadata    map[string]string
-	Params      map[string]string
-	Graph       []Node
-}
-
-type Bindings struct {
-	Src     string `json:"src"`
-	SrcKey  string `json:"src_key"`
-	Dest    string `json:"dest"`
-	DestKey string `json:"dest_key"`
-}
-
-// End Nulecule structs
-
-type NuleculeDetail struct {
-	Nulecule Answers    `json:"nulecule"`
-	Bindings []Bindings `json:"bindings"`
-}
-
-func getBindings(nulecule_path string) []Bindings {
-	//func getBindings(nulecule_path string) {
-	nulecule_file := "nulecule-library/" + nulecule_path + "/Nulecule"
-	nulecule, err := ioutil.ReadFile(nulecule_file)
-	if err != nil {
-		log.Fatal(err)
-	}
-	n := Nulecule{}
-	err = yaml.Unmarshal(nulecule, &n)
-	if err != nil {
-		log.Fatal(err)
-	}
-	bindings := make([]Bindings, 0)
-	for _, graph := range n.Graph {
-		for _, param := range graph.Params {
-			for _, bind := range param.Binds {
-				bindval := strings.Split(bind, "::")
-				b := Bindings{graph.Name, param.Name, bindval[0], bindval[1]}
-				bindings = append(bindings, b)
-			}
-		}
-	}
-	return bindings
-}
-
-func getAnswersFromFile(nulecule_path string) Answers {
-	os.Remove("answers.conf")
-	/*
-		output, err := exec.Command("atomicapp", "genanswers", "nulecule-library/"+nulecule_path).CombinedOutput()
-		if err != nil {
-			fmt.Println("Error running atomicapp")
-		}
-	*/
-	output := runCommand("atomicapp", "genanswers", "nulecule-library/"+nulecule_path)
-	fmt.Println(string(output))
-	answers, err := ioutil.ReadFile("answers.conf")
-	if err != nil {
-		log.Fatal(err)
-	}
-	return parseBasicINI(string(answers))
-}
-
-func getNuleculeList() map[string][]string {
-	files, _ := ioutil.ReadDir("./nulecule-library")
-	nulecules := make([]string, 0)
-	for _, f := range files {
-		if f.IsDir() {
-			nulecules = append(nulecules, f.Name())
-		}
-	}
-	return map[string][]string{"nulecules": nulecules}
+func IndexHandler(w http.ResponseWriter, r *http.Request) {
+	t, _ := template.ParseFiles("static/index.html")
+	t.Execute(w, nil)
 }
 
 func Nulecules(w http.ResponseWriter, r *http.Request) {
-	fmt.Println("Entered Nulecules method")
 	json.NewEncoder(w).Encode(getNuleculeList())
 }
 
 func NuleculeDetails(w http.ResponseWriter, r *http.Request) {
 	fmt.Println("Entered NuleculeDetails method")
 	vars := mux.Vars(r)
-	nulecule_id := vars["id"]
-	details := NuleculeDetail{getAnswersFromFile(nulecule_id), getBindings(nulecule_id)}
+	registry := vars["registry"]
+	nuleculeId := vars["id"]
+
+	downloadNulecule(registry, nuleculeId)
+
+	// atomicapp 0.6.4 changed the answer.conf file format and namespaces
+	// component names with their container name, i.e.
+	// "mariadb-app" vs "mariadb-centos7-atomicapp:mariadb-app"
+	// stripContainerNamespace will strip off the container namespace
+	// to maintain backwards compatibility for the cap UI.
+
+	strippedNamespaces, answers := stripNamespaces(
+		getAnswersFromFile(registry, nuleculeId),
+	)
+
+	for _, strippedNamespace := range strippedNamespaces {
+		namespaceManifest.insert(registry, nuleculeId,
+			strippedNamespace.namespace, strippedNamespace.nodeName)
+	}
+
+	details := NuleculeDetail{
+		answers,
+		getBindings(registry, nuleculeId),
+	}
+
 	json.NewEncoder(os.Stdout).Encode(details)
 	json.NewEncoder(w).Encode(details)
-}
-
-func genUUID() string {
-	return strings.Trim(string(runCommand("/usr/bin/uuidgen")), "\n")
-}
-
-func getToken() string {
-	return strings.Trim(string(runCommand("/usr/bin/oc", "whoami", "-t")), "\n")
-}
-
-func createNewProject(project string) string {
-	return strings.Trim(string(runCommand("/usr/bin/oc", "new-project", project)), "\n")
-}
-
-func addProviderDetails(answers Answers) {
-	uuid := genUUID()
-	token := getToken()
-	project_name := "cap-" + uuid
-	output := createNewProject(project_name)
-	fmt.Println(output)
-	provider := make(map[string]string)
-	provider["namespace"] = project_name
-	provider["provider"] = "openshift"
-	provider["provider-api"] = "https://10.1.2.2:8443"
-	provider["provider-auth"] = token
-	provider["provider-cafile"] = "/host/var/lib/openshift/openshift.local.config/master/ca.crt"
-	provider["providertlsverify"] = "False"
-	answers["general"] = provider
 }
 
 func NuleculeUpdate(w http.ResponseWriter, r *http.Request) {
 	fmt.Println("Entered NuleculeUpdate method")
 	// update the nulecule answers file
 	vars := mux.Vars(r)
-	nulecule_id := vars["id"]
-	fmt.Println(nulecule_id)
-	fmt.Println("NuleculeUpdate!")
+	nuleculeId := vars["id"]
+	registry := vars["registry"]
 
 	// get the posted answers
 	// Answers is a map of maps
 	res_map := make(map[string]Answers)
-
 	json.NewDecoder(r.Body).Decode(&res_map)
 
-	// ERIK TODO:
-	// -> Convert answer JSON params -> map[string]interface{}
-	// -> answerMap := addProviderDetails(map[string]interface{}) < adds provider necessary details to [general]
-	// -> iniStruct := genINIFromAnswers(answerMap)
-	// -> iniStruct.write(/* target nulecule directory */
-	addProviderDetails(res_map["nulecule"])
-
-	home_dir := getHomeDir()
-	answers_dir := path.Join(home_dir, "answers", nulecule_id)
-	os.MkdirAll(answers_dir, 0755)
-
-	f, err := os.Create(path.Join(answers_dir, "answers.conf"))
-	if err != nil {
-		fmt.Println("Error creating answers.conf")
-	}
-
-	defer f.Close()
-
-	for k, v := range res_map["nulecule"] {
-		//fmt.Print("[" + k + "]\n")
-		fmt.Fprint(f, "["+k+"]\n")
-		for k1, v1 := range v {
-			//fmt.Printf("%s=%s\n", k1, v1)
-			fmt.Fprintf(f, "%s=%s\n", k1, v1)
-		}
-	}
+	// TODO: Consider better way to uniquely ID projects instead of a UUID
+	// Could also use UUIDs as bookkeeping on the backend with a more friendly
+	// project name provided by the user on the front end.
+	projectName := addProviderDetails(res_map["nulecule"])
+	createNewProject(projectName)
+	injectNamespaces(namespaceManifest, res_map["nulecule"], registry, nuleculeId)
+	writeUserAnswersToFile(registry, nuleculeId, res_map)
 
 	json.NewEncoder(w).Encode(res_map) // Success, fail?
-}
-
-func getHomeDir() string {
-	usr, err := user.Current()
-	if err != nil {
-		log.Fatal(err)
-	}
-	return usr.HomeDir
 }
 
 func NuleculeDeploy(w http.ResponseWriter, r *http.Request) {
 	fmt.Println("Entered NuleculeDeploy method")
 	vars := mux.Vars(r)
 	nulecule_id := vars["id"]
-
-	home_dir := getHomeDir()
-
-	// Create nulecules dir if it doens't already exist
-	nulecules_dir := path.Join(home_dir, "nulecules")
-	mode := os.FileMode(int(0755))
-	os.Mkdir(nulecules_dir, mode)
-
-	nulecule_dir := path.Join(nulecules_dir, nulecule_id)
-
-	// Download atomicapp
-	download_script := path.Join(mainGoDir(), "download_atomicapp.sh")
-	output := runCommand("bash", download_script, nulecule_id)
-	fmt.Println(string(output))
-
-	// Fix the fact that the entire thing is owned by root -.- WHY
-	output = runCommand(
-		"sudo", "chown", "-R", "vagrant:vagrant", nulecule_dir)
-	fmt.Println(string(output))
-
-	// Copy in generated answers.conf from $HOME/answers working directory
-	answers_conf_src := path.Join(home_dir, "answers", nulecule_id, "answers.conf")
-	output = runCommand("cp", answers_conf_src, nulecule_dir)
-	fmt.Println(string(output))
+	registry := vars["registry"]
 
 	// Run the atomicapp!
 	run_script := path.Join(mainGoDir(), "run_atomicapp.sh")
-	output = runCommand("bash", run_script, nulecule_id)
+	output := runCommand("bash", run_script, registry, nulecule_id)
 	fmt.Println(string(output))
 
 	// TODO: EXPOSE ROUTE!
@@ -286,44 +132,4 @@ func NuleculeDeploy(w http.ResponseWriter, r *http.Request) {
 	res_map["result"] = "success"
 
 	json.NewEncoder(w).Encode(res_map) // Success, fail?
-}
-
-func IndexHandler(w http.ResponseWriter, r *http.Request) {
-	t, _ := template.ParseFiles("static/index.html")
-	t.Execute(w, nil)
-}
-
-func wrapScriptCmd(cmd string) string {
-	return fmt.Sprintf("\"%s\"", cmd)
-}
-
-func mainGoDir() string {
-	/*
-		_, filename, _, _ := runtime.Caller(0)
-		return fmt.Sprintf(path.Dir(filename))
-	*/
-	return "."
-}
-
-func main() {
-	r := mux.NewRouter()
-
-	// API routes
-	r.HandleFunc("/nulecules", Nulecules)
-	r.HandleFunc("/nulecules/{id}", NuleculeDetails).Methods("GET")
-	r.HandleFunc("/nulecules/{id}", NuleculeUpdate).Methods("POST")
-	r.HandleFunc("/nulecules/{id}/deploy", NuleculeDeploy).Methods("POST")
-
-	// Setup static file server at /static/, used for stuff like js
-	fs := http.StripPrefix("/static/", http.FileServer(http.Dir("./static")))
-	r.PathPrefix("/static/").Handler(fs)
-
-	// Serve index template
-	r.HandleFunc("/", IndexHandler)
-
-	fmt.Println("Listening on localhost:3001")
-	allowed_headers := handlers.AllowedHeaders([]string{"Content-Type"})
-	log.Fatal(http.ListenAndServe(":3001", handlers.CORS(
-		allowed_headers,
-	)(r)))
 }

--- a/nulecule_list.yaml
+++ b/nulecule_list.yaml
@@ -1,0 +1,5 @@
+---
+nulecules:
+  - eriknelson/etherpad-atomicapp
+  - eriknelson/guestbookgo-atomicapp
+  - eriknelson/wordpress-atomicapp

--- a/run_atomicapp.sh
+++ b/run_atomicapp.sh
@@ -1,1 +1,15 @@
-script -c "atomic run projectatomic/$1 $HOME/nulecules/$1 -v" /dev/null
+#!/bin/bash
+registry="$1"
+nulecule_name="$2"
+nulecule_dir=$HOME/nulecules/$registry/$nulecule_name
+
+echo "============================================================"
+echo "CAP RUNNING NULECULE:"
+echo "REGISTRY: $registry"
+echo "NULECULE_NAME: $nulecule_name"
+echo "NULECULE_DIR: $nulecule_dir"
+echo "============================================================"
+
+script -c " cd $nulecule_dir && \\
+  atomic run $registry/$nulecule_name -v \\
+  -a $nulecule_dir/answers.conf.gen --provider openshift" /dev/null

--- a/util.go
+++ b/util.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"os/user"
+	"path"
+	"regexp"
+	"strings"
+
+	yaml "gopkg.in/yaml.v1"
+)
+
+const ANSWERS_FILE = "answers.conf"         // file produced by genanswers
+const ANSWERS_FILE_GEN = "answers.conf.gen" // Answers file w/ user provided answers
+
+func genUUID() string {
+	return strings.Trim(string(runCommand("/usr/bin/uuidgen")), "\n")
+}
+
+// File system helpers
+func mainGoDir() string {
+	/*
+		_, filename, _, _ := runtime.Caller(0)
+		return fmt.Sprintf(path.Dir(filename))
+	*/
+	return "."
+}
+
+func getHomeDir() string {
+	usr, err := user.Current()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return usr.HomeDir
+}
+
+func getNuleculesDir() string {
+	return path.Join(getHomeDir(), "nulecules")
+}
+
+func getNuleculeDir(registry string, nuleculeId string) string {
+	return path.Join(getNuleculesDir(), registry, nuleculeId)
+}
+
+func getNuleculeList() NuleculeList {
+	nuleculeListFile, _ := ioutil.ReadFile("./nulecule_list.yaml")
+	nuleculeList := NuleculeList{}
+	err := yaml.Unmarshal(nuleculeListFile, &nuleculeList)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return nuleculeList
+}
+
+func writeUserAnswersToFile(
+	registry string,
+	nuleculeId string,
+	res_map map[string]Answers,
+) {
+	nuleculeDir := getNuleculeDir(registry, nuleculeId)
+	answersFile := path.Join(nuleculeDir, ANSWERS_FILE_GEN)
+
+	f, err := os.Create(answersFile)
+	if err != nil {
+		log.Fatal("Error writing user answers")
+	}
+
+	defer f.Close()
+
+	// Actually write dict out to file in ini format
+	for k, v := range res_map["nulecule"] {
+		//fmt.Print("[" + k + "]\n")
+		fmt.Fprint(f, "["+k+"]\n")
+		for k1, v1 := range v {
+			//fmt.Printf("%s=%s\n", k1, v1)
+			fmt.Fprintf(f, "%s=%s\n", k1, v1)
+		}
+	}
+}
+
+// Command helpers
+func runCommand(cmd string, args ...string) []byte {
+	output, err := exec.Command(cmd, args...).CombinedOutput()
+	if err != nil {
+		fmt.Println("Error running " + cmd)
+	}
+	return output
+}
+
+// Parsing helpers
+func getAnswersFromFile(registry string, nuleculeId string) Answers {
+	nuleculeDir := getNuleculeDir(registry, nuleculeId)
+	answersFile := path.Join(nuleculeDir, ANSWERS_FILE)
+	answers, err := ioutil.ReadFile(answersFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return parseBasicINI(string(answers))
+}
+
+type StrippedNamespace struct {
+	namespace string
+	nodeName  string
+}
+
+func stripNamespaces(answers Answers) ([]StrippedNamespace, Answers) {
+	var namespace, nodeName string
+	var strippedNamespaces = []StrippedNamespace{}
+
+	for answerKey, _ := range answers {
+		re, _ := regexp.Compile("^(.*):(.*)$")
+		matchGroups := re.FindStringSubmatch(answerKey)
+
+		//matchGroups[0] is the full string, matchGroups[...] are the extracted vals
+		if len(matchGroups) != 3 {
+			continue
+		}
+
+		// Replace namespaced key with stripped key
+		namespace = matchGroups[1]
+		nodeName = matchGroups[2]
+		answer := answers[answerKey]
+		delete(answers, answerKey)
+		answers[namespace] = answer
+
+		strippedNamespaces = append(strippedNamespaces,
+			StrippedNamespace{namespace, nodeName})
+	}
+
+	//return namespace, nodeName, answers
+	return strippedNamespaces, answers
+}
+
+func injectNamespaces(
+	namespaceManifest NamespaceManifest,
+	answers Answers,
+	registry string,
+	nuleculeId string,
+) {
+	atomicAppId := NewAtomicAppId(registry, nuleculeId)
+	strippedNamespaces, contains := namespaceManifest[atomicAppId]
+
+	// If no namespaces were stripped, nothing needs to be done
+	if !contains {
+		return
+	}
+
+	// Iterate over stripped namespaces and add them back into answer sections
+	for strippedNamespace, strippedNodeName := range strippedNamespaces {
+		for section, sectionAnswers := range answers {
+			// If answers contains section header that matches a stripped namespace,
+			// create fully qualified section header and add it back to the answers
+			if section != strippedNamespace {
+				continue
+			}
+
+			fqSection := fmt.Sprintf("%s:%s", strippedNamespace, strippedNodeName)
+			delete(answers, section)
+			answers[fqSection] = sectionAnswers
+		}
+	}
+}
+
+func parseBasicINI(data string) map[string]map[string]string {
+	/*
+		find first [ then find matching ]. Everything between them is the first key. Read until next [ or end of string.
+	*/
+	var answers = make(map[string]map[string]string)
+	values := strings.SplitAfter(data, "\n")
+	var key string
+	for _, str := range values {
+		if strings.HasPrefix(str, "[") {
+			key = strings.Trim(str, "[]\n")
+			answers[key] = make(map[string]string)
+		} else {
+			subvalue := strings.Split(str, " = ")
+			answers[key][subvalue[0]] = strings.Trim(subvalue[1], "\n")
+		}
+	}
+
+	//fmt.Println(answers)
+	return answers
+}
+
+func getBindings(registry string, nuleculeId string) []Bindings {
+	nuleculeFile := path.Join(getNuleculeDir(registry, nuleculeId), "Nulecule")
+	nulecule, err := ioutil.ReadFile(nuleculeFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	n := Nulecule{}
+	err = yaml.Unmarshal(nulecule, &n)
+	if err != nil {
+		log.Fatal(err)
+	}
+	bindings := make([]Bindings, 0)
+	for _, graph := range n.Graph {
+		for _, param := range graph.Params {
+			for _, bind := range param.Binds {
+				bindval := strings.Split(bind, "::")
+				b := Bindings{graph.Name, param.Name, bindval[0], bindval[1]}
+				bindings = append(bindings, b)
+			}
+		}
+	}
+	return bindings
+}
+
+func addProviderDetails(answers Answers) string {
+	uuid := genUUID()
+	token := getToken()
+	projectName := "cap-" + uuid
+	provider := make(map[string]string)
+	provider["namespace"] = projectName
+	provider["provider"] = "openshift"
+	provider["provider-api"] = "https://10.1.2.2:8443"
+	provider["provider-auth"] = token
+	provider["provider-cafile"] = "/host/var/lib/openshift/openshift.local.config/master/ca.crt"
+	provider["providertlsverify"] = "False"
+	answers["general"] = provider
+	return projectName
+}
+
+// Openshift helpers
+func getToken() string {
+	return strings.Trim(string(runCommand("/usr/bin/oc", "whoami", "-t")), "\n")
+}
+
+func createNewProject(project string) string {
+	return strings.Trim(string(runCommand("/usr/bin/oc", "new-project", project)), "\n")
+}
+
+// Atomic helpers
+func downloadNulecule(registry string, nuleculeId string) {
+	download_script := path.Join(mainGoDir(), "download_atomicapp.sh")
+	output := runCommand("bash", download_script, registry, nuleculeId)
+	fmt.Println(string(output))
+}


### PR DESCRIPTION
* Rips out need for atomicapp and uses atomicapp strictly
* Use nulecule_list.yaml as a manifest of available nulecules instead
of reading out of nulecule-library
* Pulled out nulecule-library
* Parameterization so we can deploy from different registries, strictly
off the manifest file
* Split project out for organization into a few different files

Depends on: https://github.com/fusor/cap-ui/pull/2